### PR TITLE
fix(mobile): programmatic scroll guard for marquee autoplay

### DIFF
--- a/components/useMobileMarqueeAutoplay.ts
+++ b/components/useMobileMarqueeAutoplay.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 
 type Options = {
   speedPxPerSec?: number;
@@ -17,6 +17,8 @@ export function useMobileMarqueeAutoplay(
 ) {
   const speedPxPerSec = options?.speedPxPerSec ?? 12;
   const idleResumeMs = options?.idleResumeMs ?? 1000;
+  /** True only for the scroll event(s) immediately following our own scrollLeft / scrollTo writes. */
+  const isProgrammaticScrollRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) return;
@@ -59,6 +61,11 @@ export function useMobileMarqueeAutoplay(
     };
 
     const onScroll = () => {
+      if (isProgrammaticScrollRef.current) {
+        isProgrammaticScrollRef.current = false;
+        autoplayAnchor = scroller.scrollLeft;
+        return;
+      }
       if (touching) return;
 
       if (paused) {
@@ -101,6 +108,7 @@ export function useMobileMarqueeAutoplay(
       if (!paused) {
         const loopW = scroller.scrollWidth / 2;
         if (loopW > 0) {
+          isProgrammaticScrollRef.current = true;
           while (scroller.scrollLeft >= loopW) {
             scroller.scrollLeft -= loopW;
           }
@@ -128,6 +136,7 @@ export function useMobileMarqueeAutoplay(
     fontsReady.then(start);
 
     return () => {
+      isProgrammaticScrollRef.current = false;
       cancelAnimationFrame(raf);
       clearResume();
       ro.disconnect();


### PR DESCRIPTION
## Root cause
In `useMobileMarqueeAutoplay`, the RAF loop writes `scrollLeft` then calls `scrollTo`. WebKit delivers a `scroll` event for that programmatic write. `onScroll` compared `scrollLeft` to `autoplayAnchor`; when the diff hit the ≥ 3 px threshold, it set `paused = true` and scheduled `bumpIdle`. Our own scroll was being classified as user swipe on every frame, so autoplay continuously paused itself.

## Fix (mobile only)
Added a single boolean `useRef` (`isProgrammaticScrollRef`). Set `true` immediately before the programmatic write in the RAF loop. At the top of `onScroll`: if the flag is set, clear it, sync the anchor, and return — no pause, no bumpIdle. The rest of `onScroll` (user swipe detection, `paused`, `bumpIdle`) is unchanged.

The hook is only called with `enabled = true` when `isMobile && count >= 2`. On desktop, the hook is a no-op. No desktop files or desktop branches were changed.

## Files changed
`components/useMobileMarqueeAutoplay.ts` — 10 line diff: import `useRef`, add `isProgrammaticScrollRef`, guard in `onScroll`, set flag in `loop`, clear in cleanup.

## Manual QA checklist
- [ ] iPhone Safari (2+ items): autoplay drifts automatically
- [ ] iPhone Safari: manual swipe pauses autoplay
- [ ] iPhone Safari: autoplay resumes after ~1 s idle
- [ ] Desktop: marquee unchanged