### PR TITLE
fix(home): GovAI hero → /blog/govai

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -864,7 +864,7 @@ export default function HomePage() {
             </p>
             <div className="mt-1 flex justify-center">
               <Link
-                href="/blog#govai"
+                href="/blog/govai"
                 className="text-[10px] font-semibold text-[#004cff] hover:opacity-90 transition-opacity"
               >
                 View GovAI


### PR DESCRIPTION
The GovAI highlight "View GovAI" link on the homepage hero pointed to `/blog#govai`. It now opens the GovAI article directly at `/blog/govai`.

Made with [Cursor](https://cursor.com)